### PR TITLE
Fix hang during initialization

### DIFF
--- a/uefidoom/d_main.c
+++ b/uefidoom/d_main.c
@@ -672,7 +672,7 @@ void IdentifyVersion(void)
     }
 
 
-	Print(L"Game mode indeterminate.\n");
+	printf("Game mode indeterminate.\n");
 	gamemode = indetermined;
 
 	// We don't abort. Let's see what the PWAD contains.

--- a/uefidoom/doom.inf
+++ b/uefidoom/doom.inf
@@ -81,6 +81,9 @@ w_wad.c
 wi_stuff.c
 z_zone.c
 
+[Sources.X64]
+efi/chkstk.nasm | MSFT
+
 [Packages]
   MdePkg/MdePkg.dec
   MdeModulePkg/MdeModulePkg.dec
@@ -107,4 +110,5 @@ z_zone.c
 [BuildOptions]
     *:*_*_*_CC_FLAGS      = -DNORMALUNIX
     MSFT:*_*_*_CC_FLAGS      = -DNORMALUNIX /W2 /WX- /WL /FAs
+    GCC:*_*_*_CC_FLAGS       = -fno-stack-clash-protection -Wno-error
 

--- a/uefidoom/efi/alloca.h
+++ b/uefidoom/efi/alloca.h
@@ -1,0 +1,15 @@
+#ifndef EFI_ALLOCA_H
+#define EFI_ALLOCA_H
+
+#include <stddef.h>
+
+#if defined(__GNUC__)
+    #define alloca __builtin_alloca
+#elif defined(_MSC_VER)
+    #define alloca(size) _alloca(size)
+    void *_alloca(size_t);
+#else
+    #error Not supported
+#endif
+
+#endif // EFI_ALLOCA_H

--- a/uefidoom/efi/chkstk.nasm
+++ b/uefidoom/efi/chkstk.nasm
@@ -1,0 +1,6 @@
+SECTION .text
+
+; A stub needed for alloca() support in MS compiler
+global ASM_PFX(__chkstk)
+ASM_PFX(__chkstk):
+    ret

--- a/uefidoom/efi/i_net.c
+++ b/uefidoom/efi/i_net.c
@@ -2,6 +2,7 @@
 #include <i_net.h>
 #include <m_argv.h>
 #include <doomstat.h>
+#include <stdlib.h>
 
 void I_InitNetwork (void)
 {

--- a/uefidoom/efi/i_video.c
+++ b/uefidoom/efi/i_video.c
@@ -1,6 +1,7 @@
 #include <i_video.h>
 #include <v_video.h>
 #include <d_event.h>
+#include <d_main.h>
 #include <doomdef.h>
 #define STB_IMAGE_RESIZE_IMPLEMENTATION 1
 #include "stb_image_resize.h"
@@ -40,6 +41,8 @@ static boolean getInput = true;
 static EFI_KEY_DATA keydata[4096];
 static unsigned int keycounter;
 #define FRAME_SCALE 2
+
+static int xlatekey(EFI_INPUT_KEY* efiKey);
 
 ////////////////////////////////////////////////////////////////////
 

--- a/uefidoom/m_misc.c
+++ b/uefidoom/m_misc.c
@@ -392,8 +392,7 @@ void M_LoadDefaults (void)
 			if (!isstring)
 			    *defaults[i].location = parm;
 			else
-			    *defaults[i].location =
-				(int) newstring;
+			    *(char**)defaults[i].location = newstring;
 			break;
 		    }
 	    }

--- a/uefidoom/p_saveg.c
+++ b/uefidoom/p_saveg.c
@@ -101,7 +101,7 @@ void P_UnArchivePlayers (void)
 	    if (players[i]. psprites[j].state)
 	    {
 		players[i]. psprites[j].state 
-		    = &states[ (int)players[i].psprites[j].state ];
+		    = &states[ (size_t)players[i].psprites[j].state ];
 	    }
 	}
     }
@@ -299,11 +299,11 @@ void P_UnArchiveThinkers (void)
 	    mobj = Z_Malloc (sizeof(*mobj), PU_LEVEL, NULL);
 	    memcpy (mobj, save_p, sizeof(*mobj));
 	    save_p += sizeof(*mobj);
-	    mobj->state = &states[(int)mobj->state];
+	    mobj->state = &states[(size_t)mobj->state];
 	    mobj->target = NULL;
 	    if (mobj->player)
 	    {
-		mobj->player = &players[(int)mobj->player-1];
+		mobj->player = &players[(size_t)mobj->player-1];
 		mobj->player->mo = mobj;
 	    }
 	    P_SetThingPosition (mobj);
@@ -498,7 +498,7 @@ void P_UnArchiveSpecials (void)
 	    ceiling = Z_Malloc (sizeof(*ceiling), PU_LEVEL, NULL);
 	    memcpy (ceiling, save_p, sizeof(*ceiling));
 	    save_p += sizeof(*ceiling);
-	    ceiling->sector = &sectors[(int)ceiling->sector];
+	    ceiling->sector = &sectors[(size_t)ceiling->sector];
 	    ceiling->sector->specialdata = ceiling;
 
 	    if (ceiling->thinker.function.acp1)
@@ -513,7 +513,7 @@ void P_UnArchiveSpecials (void)
 	    door = Z_Malloc (sizeof(*door), PU_LEVEL, NULL);
 	    memcpy (door, save_p, sizeof(*door));
 	    save_p += sizeof(*door);
-	    door->sector = &sectors[(int)door->sector];
+	    door->sector = &sectors[(size_t)door->sector];
 	    door->sector->specialdata = door;
 	    door->thinker.function.acp1 = (actionf_p1)T_VerticalDoor;
 	    P_AddThinker (&door->thinker);
@@ -524,7 +524,7 @@ void P_UnArchiveSpecials (void)
 	    floor = Z_Malloc (sizeof(*floor), PU_LEVEL, NULL);
 	    memcpy (floor, save_p, sizeof(*floor));
 	    save_p += sizeof(*floor);
-	    floor->sector = &sectors[(int)floor->sector];
+	    floor->sector = &sectors[(size_t)floor->sector];
 	    floor->sector->specialdata = floor;
 	    floor->thinker.function.acp1 = (actionf_p1)T_MoveFloor;
 	    P_AddThinker (&floor->thinker);
@@ -535,7 +535,7 @@ void P_UnArchiveSpecials (void)
 	    plat = Z_Malloc (sizeof(*plat), PU_LEVEL, NULL);
 	    memcpy (plat, save_p, sizeof(*plat));
 	    save_p += sizeof(*plat);
-	    plat->sector = &sectors[(int)plat->sector];
+	    plat->sector = &sectors[(size_t)plat->sector];
 	    plat->sector->specialdata = plat;
 
 	    if (plat->thinker.function.acp1)
@@ -550,7 +550,7 @@ void P_UnArchiveSpecials (void)
 	    flash = Z_Malloc (sizeof(*flash), PU_LEVEL, NULL);
 	    memcpy (flash, save_p, sizeof(*flash));
 	    save_p += sizeof(*flash);
-	    flash->sector = &sectors[(int)flash->sector];
+	    flash->sector = &sectors[(size_t)flash->sector];
 	    flash->thinker.function.acp1 = (actionf_p1)T_LightFlash;
 	    P_AddThinker (&flash->thinker);
 	    break;
@@ -560,7 +560,7 @@ void P_UnArchiveSpecials (void)
 	    strobe = Z_Malloc (sizeof(*strobe), PU_LEVEL, NULL);
 	    memcpy (strobe, save_p, sizeof(*strobe));
 	    save_p += sizeof(*strobe);
-	    strobe->sector = &sectors[(int)strobe->sector];
+	    strobe->sector = &sectors[(size_t)strobe->sector];
 	    strobe->thinker.function.acp1 = (actionf_p1)T_StrobeFlash;
 	    P_AddThinker (&strobe->thinker);
 	    break;
@@ -570,7 +570,7 @@ void P_UnArchiveSpecials (void)
 	    glow = Z_Malloc (sizeof(*glow), PU_LEVEL, NULL);
 	    memcpy (glow, save_p, sizeof(*glow));
 	    save_p += sizeof(*glow);
-	    glow->sector = &sectors[(int)glow->sector];
+	    glow->sector = &sectors[(size_t)glow->sector];
 	    glow->thinker.function.acp1 = (actionf_p1)T_Glow;
 	    P_AddThinker (&glow->thinker);
 	    break;

--- a/uefidoom/r_data.c
+++ b/uefidoom/r_data.c
@@ -45,7 +45,7 @@ rcsid[] = "$Id: r_data.c,v 1.4 1997/02/03 16:47:55 b1 Exp $";
 #include "r_data.h"
 
 #include <stdint.h>
-#include <stdlib.h>
+#include <alloca.h>
 
 //
 // Graphics.
@@ -319,7 +319,7 @@ void R_GenerateLookup (int texnum)
     //  that are covered by more than one patch.
     // Fill in the lump / offset, so columns
     //  with only a single patch are all done.
-    patchcount = (byte *)calloc (texture->width, 1);
+    patchcount = (byte *)alloca (texture->width);
     memset (patchcount, 0, texture->width);
     patch = texture->patches;
 		
@@ -446,7 +446,7 @@ void R_InitTextures (void)
     names = W_CacheLumpName ("PNAMES", PU_STATIC);
     nummappatches = LONG ( *((int *)names) );
     name_p = names+4;
-    patchlookup = calloc (nummappatches*sizeof(*patchlookup), 1);
+    patchlookup = alloca (nummappatches*sizeof(*patchlookup));
   
     for (i=0 ; i<nummappatches ; i++)
     {
@@ -645,7 +645,7 @@ void R_InitColormaps (void)
     lump = W_GetNumForName("COLORMAP"); 
     length = W_LumpLength (lump) + 255; 
     colormaps = Z_Malloc (length, PU_STATIC, 0); 
-    colormaps = (byte *)( ((int)colormaps + 255)&~0xff); 
+    colormaps = (byte *)( ((size_t)colormaps + 255)&~(size_t)0xff); 
     W_ReadLump (lump,colormaps); 
 }
 
@@ -765,7 +765,7 @@ void R_PrecacheLevel (void)
 	return;
     
     // Precache flats.
-    flatpresent = calloc(numflats, 1);
+    flatpresent = alloca(numflats);
     memset (flatpresent,0,numflats);	
 
     for (i=0 ; i<numsectors ; i++)
@@ -787,7 +787,7 @@ void R_PrecacheLevel (void)
     }
     
     // Precache textures.
-    texturepresent = calloc(numtextures, 1);
+    texturepresent = alloca(numtextures);
     memset (texturepresent,0, numtextures);
 	
     for (i=0 ; i<numsides ; i++)
@@ -822,7 +822,7 @@ void R_PrecacheLevel (void)
     }
     
     // Precache sprites.
-    spritepresent = calloc(numsprites, 1);
+    spritepresent = alloca(numsprites);
     memset (spritepresent,0, numsprites);
 	
     for (th = thinkercap.next ; th != &thinkercap ; th=th->next)

--- a/uefidoom/r_draw.c
+++ b/uefidoom/r_draw.c
@@ -461,7 +461,7 @@ void R_InitTranslationTables (void)
     int		i;
 	
     translationtables = Z_Malloc (256*3+255, PU_STATIC, 0);
-    translationtables = (byte *)(( (int)translationtables + 255 )& ~255);
+    translationtables = (byte *)(( (size_t)translationtables + 255 )& ~(size_t)255);
     
     // translate just the 16 green colors
     for (i=0 ; i<256 ; i++)

--- a/uefidoom/sound/common.h
+++ b/uefidoom/sound/common.h
@@ -17,6 +17,8 @@ typedef	int		int32_t ;
 typedef	long	int32_t ;
 #endif
 
+#include "float_cast.h"
+
 #define	SRC_MAX_RATIO			256
 #define	SRC_MAX_RATIO_STR		"256"
 

--- a/uefidoom/w_wad.c
+++ b/uefidoom/w_wad.c
@@ -35,7 +35,7 @@ rcsid[] = "$Id: w_wad.c,v 1.5 1997/02/03 16:47:57 b1 Exp $";
 #include <stdlib.h>
 #include <fcntl.h>
 #include <sys/stat.h>
-//#include <alloca.h>
+#include <alloca.h>
 #define O_BINARY		0
 //#endif
 
@@ -48,11 +48,6 @@ rcsid[] = "$Id: w_wad.c,v 1.5 1997/02/03 16:47:57 b1 Exp $";
 #pragma implementation "w_wad.h"
 #endif
 #include "w_wad.h"
-
-void* alloca(size_t size)
-{
-	return malloc(size);
-}
 
 
 
@@ -199,7 +194,7 @@ void W_AddFile (char *filename)
 	header.numlumps = LONG(header.numlumps);
 	header.infotableofs = LONG(header.infotableofs);
 	length = header.numlumps*sizeof(filelump_t);
-	fileinfo = malloc (length);
+	fileinfo = alloca (length);
 	lseek (handle, header.infotableofs, SEEK_SET);
 	read (handle, fileinfo, length);
 	numlumps += header.numlumps;
@@ -221,7 +216,7 @@ void W_AddFile (char *filename)
 	lump_p->handle = storehandle;
 	lump_p->position = LONG(fileinfo->filepos);
 	lump_p->size = LONG(fileinfo->size);
-	strncpy (lump_p->name, fileinfo->name, 8);
+	memcpy (lump_p->name, fileinfo->name, 8);
     }
 	
     if (reloadname)
@@ -256,7 +251,7 @@ void W_Reload (void)
     lumpcount = LONG(header.numlumps);
     header.infotableofs = LONG(header.infotableofs);
     length = lumpcount*sizeof(filelump_t);
-    fileinfo = malloc (length);
+    fileinfo = alloca (length);
     lseek (handle, header.infotableofs, SEEK_SET);
     read (handle, fileinfo, length);
     
@@ -362,6 +357,9 @@ int W_CheckNumForName (char* name)
     int		v1;
     int		v2;
     lumpinfo_t*	lump_p;
+
+    // initialize name8 with zeros
+    name8.x[0] = name8.x[1] = 0;
 
     // make the name into two integers for easy compares
     strncpy (name8.s,name,8);

--- a/uefidoom/z_zone.c
+++ b/uefidoom/z_zone.c
@@ -442,7 +442,7 @@ Z_ChangeTag2
     if (block->id != ZONEID)
 	I_Error ("Z_ChangeTag: freed a pointer without ZONEID");
 
-    if (tag >= PU_PURGELEVEL && (unsigned)block->user < 0x100)
+    if (tag >= PU_PURGELEVEL && (size_t)block->user < 0x100)
 	I_Error ("Z_ChangeTag: an owner is required for purgable blocks");
 
     block->tag = tag;

--- a/uefidoom/z_zone.h
+++ b/uefidoom/z_zone.h
@@ -78,9 +78,9 @@ typedef struct memblock_s
 
 //#define Z_DEBUG
 
-#ifdef Z_DEBUG
 #include <Library/SerialPortLib.h>
 
+#ifdef Z_DEBUG
 void Z_FreeDebug(void* ptr, const char* file, int line);
 void* Z_MallocDebug(int size, int tag, void* ptr, const char* file, int line);
 


### PR DESCRIPTION
- Enable correct `alloca()` usage.
- Use `size_t` instead of `int` for 64-bit pointer storage.
- Fix implicit declaration of some functions that led to hidden `ptr`->`int` conversion.
- Fix WAD "lump not found" issue.
- [BONUS] Support build with GCC.

Should fix #3, #8, #9.